### PR TITLE
fixes real time to use state changes instead of window.reload

### DIFF
--- a/src/app/components/App.jsx
+++ b/src/app/components/App.jsx
@@ -11,16 +11,22 @@ import socket from "../socketIOHandler";
 // Adding I18n
 import './../../i18n';
 
-const App = ({ user, isGuest }) => {
-
-  socket.on("change", () => {
-    window.location.reload();
-  })
-
-  
+const App = ({ user, isGuest, dispatch }) => {
+  // In order to attach listener only on first loading off App.
+  if(!socket.hasListeners("change")){
+    socket.on("change", ({action, payload}) => {
+      console.log({action, payload});
+      dispatch({
+        type: action,
+        payload,
+        dontPersist: true
+      })
+    })
+  }
+ 
   // Serve different pages depending on if user is logged in or not
   if (user || isGuest) {
-    //when user is connected registers socket to user for updates
+    // when user is connected registers socket to user for updates
     socket.emit("userDetails", user);
     return (
       <Switch>
@@ -40,7 +46,7 @@ const App = ({ user, isGuest }) => {
   );
 };
 
-App.propTypes = { user: PropTypes.object, isGuest: PropTypes.bool.isRequired };
+App.propTypes = { user: PropTypes.object, isGuest: PropTypes.bool.isRequired, dispatch: PropTypes.func.isRequired };
 
 const mapStateToProps = state => ({ user: state.user, isGuest: state.isGuest });
 

--- a/src/app/components/History/HistoryList.jsx
+++ b/src/app/components/History/HistoryList.jsx
@@ -31,7 +31,6 @@ class HistoryList extends Component {
 
   render() {
     const { history } = this.state;
-    console.log(history);
     const { t } = this.props;
     const {boardUsersData} = this.props;
     return (

--- a/src/app/components/History/HistoryList.jsx
+++ b/src/app/components/History/HistoryList.jsx
@@ -31,6 +31,7 @@ class HistoryList extends Component {
 
   render() {
     const { history } = this.state;
+    console.log(history);
     const { t } = this.props;
     const {boardUsersData} = this.props;
     return (

--- a/src/app/middleware/historyMiddleware.js
+++ b/src/app/middleware/historyMiddleware.js
@@ -5,11 +5,11 @@ const historyMiddleware = store => next => action => {
         currentBoardId: boardId
       } = store.getState();
 
-    if (user) {
+    if (user && !action.dontPersist) {
         if (!['PUT_BOARD_ID_IN_REDUX', 'UPDATE_FILTER','CHANGE_CARD_FILTER', 'LOAD_BOARD_USERS_DATA','SET_CURRENT_CARD',].includes(action.type)){
             fetch("/api/history", {
                 method: "POST",
-                body: JSON.stringify({userId: user._id,boardId,action: action.type}),
+                body: JSON.stringify({userId: user._id,boardId,action: action.type, payload: action.payload}),
                 headers: { "Content-Type": "application/json" },
                 credentials: "include"
               })

--- a/src/app/middleware/persistMiddleware.js
+++ b/src/app/middleware/persistMiddleware.js
@@ -14,7 +14,7 @@ const persistMiddleware = store => next => action => {
   } = store.getState();
 
   // Nothing is persisted for guest users
-  if (user) {
+  if (user && !action.dontPersist) {
     if (action.type === "DELETE_BOARD") {
       fetch("/api/board", {
         method: "DELETE",

--- a/src/app/middleware/userChangeMiddleware.js
+++ b/src/app/middleware/userChangeMiddleware.js
@@ -2,7 +2,7 @@ const userChangeMiddleware = store => next => action => {
   next(action);
   const { user, currentBoardId: boardId, boardsById } = store.getState();
 
-  if (user) {
+  if (user && !action.dontPersist) {
     if (
       [
         "UPDATE_ASSIGNED_USER",

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,7 +4,7 @@ import imageSmall from "./assets/images/backgroundImage-small.jpg";
 export const ADMIN_ROLE = "admin";
 export const READ_WRITE_ROLE = "read-write";
 export const READ_ROLE = "read";
-export const SOCKETLOCATION = process.env.REACT_APP_SOCKETLOCATION || "https://socketioamanboard.prod.services.idf/"
+export const SOCKETLOCATION = process.env.REACT_APP_SOCKETLOCATION || "localhost:8200"
 
 export const DEFAULT_ROLE = READ_WRITE_ROLE;
 export const CAN_EDIT_ROLES = [ADMIN_ROLE, READ_WRITE_ROLE];

--- a/src/server/routes/api.js
+++ b/src/server/routes/api.js
@@ -48,7 +48,7 @@ const api = db => {
   });
 
   router.post("/history", (req, res) => {
-    let { body: historyObj } = req;
+    const { body: historyObj } = req;
     history
       .insert(historyObj)
       .then(result => {
@@ -60,17 +60,17 @@ const api = db => {
   });
 
   router.post("/history/getByBoardId", (req, res) => {
-    let { id } = req.body;
+    const { id } = req.body;
     history
-      .find({ boardId: id }, "-_id")
+      .find({ boardId: id }, "-_id -payload")
       .toArray()
       .then(histories => {
-        res.json(histories);
+        res.json(histories.map(hist=> ({...hist, payload: undefined})));
       });
   });
 
   router.post("/notifications", (req, res) => {
-    let { body: notification } = req;
+    const { body: notification } = req;
     notifications
       .insert(notification)
       .then(result => {


### PR DESCRIPTION
real time updates now works without window.reload()
history object is expanded to save the change payload itself
the socket now sends the "change" event with the action type and
payload.
then the front end dispatches the corresponding object thus changing the
front end store.

resolves #8
fixes #8
solves #8 